### PR TITLE
Reorder exports in package.json

### DIFF
--- a/packages/react-select-async-paginate/package.json
+++ b/packages/react-select-async-paginate/package.json
@@ -9,9 +9,9 @@
   "module": "./dist/esm/index.js",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
This PR reorders the "exports" field in package.json to place the "types" condition first. This is recommended by TypeScript and ensures proper type resolution. Additionally, the "exports" field is order-based, so this change helps maintain correct functionality.

Relevant linting rule: EXPORTS_TYPES_SHOULD_BE_FIRST